### PR TITLE
Fixed to extract string  when there is spaces between `}` and `)`

### DIFF
--- a/DartFile.js
+++ b/DartFile.js
@@ -1,4 +1,4 @@
-/*
+/*aa
  * DartFile.js - plugin to extract resources from a Dart source code file
  *
  * Copyright (c) 2023-2024, JEDLSoft
@@ -120,7 +120,7 @@ translate("The lowest temperature is {arg1} and the highest temperature is {arg2
 */
 var reTranslate = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\)/g);
 var reTranslateWithKey = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*(key)\s*\:\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\)/g);
-var reTranslateWithArg = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*args\s*\:\s*\{(.*)\}\)/g);
+var reTranslateWithArg = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*args\s*\:\s*\{(.*)\}\s*\)/g);
 var reTranslatePlural = new RegExp(/translatePlural\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*(.*)\)/g);
 var reI18nComment = new RegExp("//\\s*i18n\\s*:\\s*(.*)$");
 

--- a/DartFile.js
+++ b/DartFile.js
@@ -1,4 +1,4 @@
-/*aa
+/*
  * DartFile.js - plugin to extract resources from a Dart source code file
  *
  * Copyright (c) 2023-2024, JEDLSoft

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ file for more details.
 
 ### v1.1.0
 * Fixed to generate the pseudo localization data correctly.
+* Fixed a bug where strings were not extracted when there were spaces between `}` and `)`.
 
 ### v1.0.1
 * Fixed the filename in the `package.json` to publish files correctly.

--- a/test/DartFile.test.js
+++ b/test/DartFile.test.js
@@ -908,7 +908,7 @@ describe("dartfile", function() {
         expect(r[0].getKey()).toBe("1#At least 1 letter|#At least {num} letters");
     });
     test("DartFileTest3", function() {
-        expect.assertions(8);
+        expect.assertions(14);
 
         var d = new DartFile({
             project: p,
@@ -920,7 +920,7 @@ describe("dartfile", function() {
         d.extract();
 
         var set = d.getTranslationSet();
-        expect(set.size()).toBe(3);
+        expect(set.size()).toBe(4);
 
         var r = set.getBySource("WOWCAST ({arg1})");
         expect(r).toBeTruthy();
@@ -931,6 +931,16 @@ describe("dartfile", function() {
         expect(r).toBeTruthy();
         expect(r.getSource()).toBe("GO TO {arg1}");
         expect(r.getKey()).toBe("GO TO {arg1}");
+
+        var r = set.getBySource("Add ({arg1} card)");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Add ({arg1} card)");
+        expect(r.getKey()).toBe("Add ({arg1} card)");
+
+        var r = set.getBySource("{appName} app cannot be deleted.");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("{appName} app cannot be deleted.");
+        expect(r.getKey()).toBe("{appName} app cannot be deleted.");
     });
     test("DartPseudoLocalization1", function() {
         expect.assertions(4);

--- a/test/DartFile.test.js
+++ b/test/DartFile.test.js
@@ -908,7 +908,7 @@ describe("dartfile", function() {
         expect(r[0].getKey()).toBe("1#At least 1 letter|#At least {num} letters");
     });
     test("DartFileTest3", function() {
-        expect.assertions(14);
+        expect.assertions(17);
 
         var d = new DartFile({
             project: p,
@@ -920,7 +920,7 @@ describe("dartfile", function() {
         d.extract();
 
         var set = d.getTranslationSet();
-        expect(set.size()).toBe(4);
+        expect(set.size()).toBe(5);
 
         var r = set.getBySource("WOWCAST ({arg1})");
         expect(r).toBeTruthy();
@@ -941,6 +941,11 @@ describe("dartfile", function() {
         expect(r).toBeTruthy();
         expect(r.getSource()).toBe("{appName} app cannot be deleted.");
         expect(r.getKey()).toBe("{appName} app cannot be deleted.");
+
+        var r = set.getBySource("The lowest temp is {arg1} and the highest temp is {arg2}.");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("The lowest temp is {arg1} and the highest temp is {arg2}.");
+        expect(r.getKey()).toBe("The lowest temp is {arg1} and the highest temp is {arg2}.");
     });
     test("DartPseudoLocalization1", function() {
         expect.assertions(4);

--- a/test/testfiles/t3.dart
+++ b/test/testfiles/t3.dart
@@ -11,7 +11,14 @@ staticString home_298(arg1) =>
       rtlCode +
       translate('Add ({arg1} card)', args: {"arg1": arg1}) + emptyString;
 
-translate(
-  '{appName} app cannot be deleted.',
-    args: {'appName': 'Settings'}
+Text(
+    translate(
+        '{appName} app cannot be deleted.',
+        args: {'appName': 'Settings'}
     ),
+    style: Style.textStyle),
+Text(
+    translate(
+        'The lowest temp is {arg1} and the highest temp is {arg2}.',
+        args: {'arg1': 15, 'arg2': 30}                 ),
+    style: Style.textStyle),

--- a/test/testfiles/t3.dart
+++ b/test/testfiles/t3.dart
@@ -10,3 +10,8 @@ staticString home_298(arg1) =>
   static String home_327(arg1) =>
       rtlCode +
       translate('Add ({arg1} card)', args: {"arg1": arg1}) + emptyString;
+
+translate(
+  '{appName} app cannot be deleted.',
+    args: {'appName': 'Settings'}
+    ),


### PR DESCRIPTION
Fixed a bug where strings were not extracted when there were spaces between `}` and `)`.
updated webos-dart sample too. https://github.com/iLib-js/ilib-loctool-samples/pull/69